### PR TITLE
use message ID 0 for log messages

### DIFF
--- a/buttplug.core/src/main/java/org/metafetish/buttplug/core/Messages/Log.java
+++ b/buttplug.core/src/main/java/org/metafetish/buttplug/core/Messages/Log.java
@@ -35,14 +35,14 @@ public class Log extends ButtplugMessage implements IButtplugMessageOutgoingOnly
     }
 
     public Log(ButtplugLogLevel logLevel, String logMessage, String tag) {
-        super(ButtplugConsts.DefaultMsgId);
+        super(0);
         this.logLevel = logLevel;
         this.logMessage = logMessage;
         this.tag = tag;
     }
 
     public Log(ButtplugLogLevel logLevel, String logMessage) {
-        super(ButtplugConsts.DefaultMsgId);
+        super(0);
         this.logLevel = logLevel;
         this.logMessage = logMessage;
         this.tag = null;


### PR DESCRIPTION
the client sends the request server info message with ID 1. if the
log messages also have ID 1, the client may interpret log messages
sent by the server during initial connect (for example, the message
which logs the connection) as reply to request server info, which
makes it break in ButtplugClient.java:169 (requestServerInfo()).